### PR TITLE
fix mutex usage race condition

### DIFF
--- a/mk_arcade_joystick_rpi.c
+++ b/mk_arcade_joystick_rpi.c
@@ -479,6 +479,9 @@ static struct mk __init *mk_probe(int *pads, int n_pads) {
         goto err_out;
     }
 
+    mutex_init(&mk->mutex);
+    setup_timer(&mk->timer, mk_timer, (long) mk);
+
     for (i = 0; i < n_pads && i < MK_MAX_DEVICES; i++) {
         if (!pads[i])
             continue;
@@ -495,9 +498,6 @@ static struct mk __init *mk_probe(int *pads, int n_pads) {
         err = -EINVAL;
         goto err_free_mk;
     }
-
-    mutex_init(&mk->mutex);
-    setup_timer(&mk->timer, mk_timer, (long) mk);
 
     return mk;
 


### PR DESCRIPTION
Initialize mutex and timer before registering the device as it can be
opened before initilization causing the kernel to crash when mk_open
tries to lock the mutex.